### PR TITLE
Provide a way to access the evaluation result programmatically

### DIFF
--- a/src/gate/plugin/learningframework/AbstractDocumentProcessor.java
+++ b/src/gate/plugin/learningframework/AbstractDocumentProcessor.java
@@ -21,7 +21,7 @@ import gate.creole.ControllerAwarePR;
 import gate.creole.ResourceInstantiationException;
 import gate.creole.AbstractLanguageAnalyser;
 import gate.creole.ExecutionException;
-import java.util.Optional;
+//import java.util.Optional;
 
 /**
  * Abstract base class for all the PRs in this plugin.

--- a/src/gate/plugin/learningframework/LF_EvaluateClassification.java
+++ b/src/gate/plugin/learningframework/LF_EvaluateClassification.java
@@ -25,6 +25,7 @@ import gate.plugin.learningframework.data.CorpusRepresentationMalletTarget;
 import gate.plugin.learningframework.engines.AlgorithmClassification;
 import gate.plugin.learningframework.engines.Engine;
 import gate.plugin.learningframework.engines.EvaluationResult;
+import gate.plugin.learningframework.engines.EvaluationResultClassification;
 import gate.plugin.learningframework.features.FeatureSpecification;
 import gate.plugin.learningframework.features.TargetType;
 import gate.util.GateRuntimeException;
@@ -265,6 +266,9 @@ public class LF_EvaluateClassification extends LF_TrainBase {
     EvaluationResult er = engine.evaluate(getAlgorithmParameters(),evaluationMethod,numberOfFolds,trainingFraction,numberOfRepeats);
     logger.info("LearningFramework: Evaluation complete!");
     logger.info(er);
+    if(getCorpus() != null && er instanceof EvaluationResultClassification) {
+      getCorpus().getFeatures().put("LearningFramework.accuracyEstimate", ((EvaluationResultClassification)er).accuracyEstimate);
+    }
   }
 
   @Override


### PR DESCRIPTION
When evaluating a classification model the evaluation result is currently only written to the logger, so it is not possible to run an evaluation from code and get a useful result out.  Here I've added the simplest possible extension point, taking the headline accuracy figure (which is a double) and putting it as a feature on the corpus being used for evaluation.  This makes the result available to other code without causing a direct dependency on the plugin classes.